### PR TITLE
Fix undefined variable error on topic creation

### DIFF
--- a/lehrer/lehrer_themen.php
+++ b/lehrer/lehrer_themen.php
@@ -942,6 +942,7 @@ foreach ($topics as &$topic) {
     let isEditing = false;
     let currentView = 'grid'; // Standard: Kachel-Ansicht
     const csrfToken = '<?= $_SESSION['csrf_token'] ?>';
+    const ajaxUrl = window.location.href;
 
     // View Toggle funktionalität
     document.querySelectorAll('.view-btn').forEach(btn => {
@@ -1063,7 +1064,7 @@ foreach ($topics as &$topic) {
             formData.append('topic_id', topicId);
             formData.append('csrf_token', csrfToken);
 
-            const response = await fetch('', {
+            const response = await fetch(ajaxUrl, {
                 method: 'POST',
                 body: formData
             });
@@ -1115,7 +1116,7 @@ foreach ($topics as &$topic) {
             formData.append('topic_id', topicId);
             formData.append('csrf_token', csrfToken);
 
-            const response = await fetch('', {
+            const response = await fetch(ajaxUrl, {
                 method: 'POST',
                 body: formData
             });
@@ -1176,7 +1177,7 @@ foreach ($topics as &$topic) {
             });
             formData.append('subject_ids', JSON.stringify(selectedSubjects));
 
-            const response = await fetch('', {
+            const response = await fetch(ajaxUrl, {
                 method: 'POST',
                 body: formData
             });


### PR DESCRIPTION
## Summary
- define `ajaxUrl` for topic actions
- use `ajaxUrl` when sending topic-related requests

## Testing
- `php -l lehrer/lehrer_themen.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac5df970832cbd01e4a7990bdcb6