### PR TITLE
Fix optional subject selection for topics

### DIFF
--- a/lehrer/lehrer_themen.php
+++ b/lehrer/lehrer_themen.php
@@ -71,9 +71,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                     throw new Exception('Titel ist erforderlich.');
                 }
                 
-                if (empty($subject_ids)) {
-                    throw new Exception('Mindestens ein Fach muss ausgewählt werden.');
-                }
                 
                 $db->beginTransaction();
                 
@@ -105,9 +102,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                     throw new Exception('Titel ist erforderlich.');
                 }
                 
-                if (empty($subject_ids)) {
-                    throw new Exception('Mindestens ein Fach muss ausgewählt werden.');
-                }
                 
                 // Prüfen ob Thema dem Lehrer gehört
                 $stmt = $db->prepare("SELECT id FROM topics WHERE id = ? AND teacher_id = ? AND school_id = ?");
@@ -942,6 +936,7 @@ foreach ($topics as &$topic) {
     let isEditing = false;
     let currentView = 'grid'; // Standard: Kachel-Ansicht
     const csrfToken = '<?= $_SESSION['csrf_token'] ?>';
+    const ajaxUrl = window.location.href;
 
     // View Toggle funktionalität
     document.querySelectorAll('.view-btn').forEach(btn => {
@@ -1063,7 +1058,7 @@ foreach ($topics as &$topic) {
             formData.append('topic_id', topicId);
             formData.append('csrf_token', csrfToken);
 
-            const response = await fetch('', {
+            const response = await fetch(ajaxUrl, {
                 method: 'POST',
                 body: formData
             });
@@ -1115,7 +1110,7 @@ foreach ($topics as &$topic) {
             formData.append('topic_id', topicId);
             formData.append('csrf_token', csrfToken);
 
-            const response = await fetch('', {
+            const response = await fetch(ajaxUrl, {
                 method: 'POST',
                 body: formData
             });
@@ -1176,7 +1171,7 @@ foreach ($topics as &$topic) {
             });
             formData.append('subject_ids', JSON.stringify(selectedSubjects));
 
-            const response = await fetch('', {
+            const response = await fetch(ajaxUrl, {
                 method: 'POST',
                 body: formData
             });


### PR DESCRIPTION
## Summary
- remove mandatory subject validation when creating or editing a topic

## Testing
- `php -l lehrer/lehrer_themen.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac5df970832cbd01e4a7990bdcb6