### PR TITLE
Make subjects optional in teacher topics

### DIFF
--- a/lehrer/lehrer_themen.php
+++ b/lehrer/lehrer_themen.php
@@ -899,7 +899,7 @@ foreach ($topics as &$topic) {
                 </div>
                 
                 <div class="form-group">
-                    <label>Fächer *</label>
+                    <label>Fächer (optional)</label>
                     <div class="subject-grid">
                         <?php foreach ($subjects as $subject): ?>
                             <label class="subject-checkbox">


### PR DESCRIPTION
## Summary
- update teacher topics form so subjects are optional

## Testing
- `php -l lehrer/lehrer_themen.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b02f6ff0832c89d10ae34b3c087d