### PR TITLE
Make subjects optional in admin topics

### DIFF
--- a/admin/lehrer_themen.php
+++ b/admin/lehrer_themen.php
@@ -28,9 +28,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                     throw new Exception('Titel ist erforderlich.');
                 }
                 
-                if (empty($subject_ids)) {
-                    throw new Exception('Mindestens ein Fach muss ausgewählt werden.');
-                }
                 
                 $db->beginTransaction();
                 
@@ -60,9 +57,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                     throw new Exception('Titel ist erforderlich.');
                 }
                 
-                if (empty($subject_ids)) {
-                    throw new Exception('Mindestens ein Fach muss ausgewählt werden.');
-                }
                 
                 // Prüfen ob Thema dem Lehrer gehört
                 $stmt = $db->prepare("SELECT id FROM topics WHERE id = ? AND teacher_id = ? AND school_id = ?");
@@ -665,7 +659,7 @@ foreach ($topics as &$topic) {
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label">Fächer auswählen *</label>
+                    <label class="form-label">Fächer auswählen (optional)</label>
                     <div class="subjects-grid" id="subjectsGrid">
                         <?php foreach ($subjects as $subject): ?>
                             <label class="subject-checkbox">

--- a/lehrer/lehrer_themen.php
+++ b/lehrer/lehrer_themen.php
@@ -899,7 +899,7 @@ foreach ($topics as &$topic) {
                 </div>
                 
                 <div class="form-group">
-                    <label>Fächer *</label>
+                    <label>Fächer (optional)</label>
                     <div class="subject-grid">
                         <?php foreach ($subjects as $subject): ?>
                             <label class="subject-checkbox">


### PR DESCRIPTION
## Summary
- make subject selection optional for admin when creating or editing topics
- update label to indicate optional subject choice

## Testing
- `php -l admin/lehrer_themen.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b02f6ff0832c89d10ae34b3c087d